### PR TITLE
Fix test failure and rename work_wur

### DIFF
--- a/library/src/lapack/roclapack_sygs2_hegs2.cpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2.cpp
@@ -38,25 +38,25 @@ rocblas_status rocsolver_sygs2_hegs2_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSV or TRMV)
-    size_t size_work_wur, size_store_wcs;
+    size_t size_work, size_store_wcs;
     // size of array of pointers (only for batched case)
     size_t size_workArr;
-    rocsolver_sygs2_hegs2_getMemorySize<T, false>(itype, n, batch_count, &size_scalars,
-                                                  &size_work_wur, &size_store_wcs, &size_workArr);
+    rocsolver_sygs2_hegs2_getMemorySize<T, false>(itype, n, batch_count, &size_scalars, &size_work,
+                                                  &size_store_wcs, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_wur,
+        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work,
                                                       size_store_wcs, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work_wur, *store_wcs, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_wur, size_store_wcs, size_workArr);
+    void *scalars, *work, *store_wcs, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work, size_store_wcs, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_wur = mem[1];
+    work = mem[1];
     store_wcs = mem[2];
     workArr = mem[3];
     if(size_scalars > 0)
@@ -65,7 +65,7 @@ rocblas_status rocsolver_sygs2_hegs2_impl(rocblas_handle handle,
     // execution
     return rocsolver_sygs2_hegs2_template<false, T>(handle, itype, uplo, n, A, shiftA, lda, strideA,
                                                     B, shiftB, ldb, strideB, batch_count,
-                                                    (T*)scalars, work_wur, store_wcs, (T**)workArr);
+                                                    (T*)scalars, work, store_wcs, (T**)workArr);
 }
 
 /*

--- a/library/src/lapack/roclapack_sygs2_hegs2.hpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2.hpp
@@ -104,7 +104,7 @@ void rocsolver_sygs2_hegs2_getMemorySize(const rocblas_eform itype,
                                          const rocblas_int n,
                                          const rocblas_int batch_count,
                                          size_t* size_scalars,
-                                         size_t* size_work_wur,
+                                         size_t* size_work,
                                          size_t* size_store_wcs,
                                          size_t* size_workArr)
 {
@@ -112,7 +112,7 @@ void rocsolver_sygs2_hegs2_getMemorySize(const rocblas_eform itype,
     if(n == 0 || batch_count == 0)
     {
         *size_scalars = 0;
-        *size_work_wur = 0;
+        *size_work = 0;
         *size_store_wcs = 0;
         *size_workArr = 0;
         return;
@@ -136,11 +136,12 @@ void rocsolver_sygs2_hegs2_getMemorySize(const rocblas_eform itype,
     {
         // extra workspace (for calling TRSV)
         *size_store_wcs = max(*size_store_wcs, sizeof(rocblas_int) * batch_count);
+        *size_work = 0;
     }
     else
     {
         // extra workspace (for calling TRMV)
-        *size_work_wur = sizeof(T) * n * batch_count;
+        *size_work = sizeof(T) * n * batch_count;
     }
 }
 
@@ -193,7 +194,7 @@ rocblas_status rocsolver_sygs2_hegs2_template(rocblas_handle handle,
                                               const rocblas_stride strideB,
                                               const rocblas_int batch_count,
                                               T* scalars,
-                                              void* work_wur,
+                                              void* work,
                                               void* store_wcs,
                                               T** workArr)
 {
@@ -328,7 +329,7 @@ rocblas_status rocsolver_sygs2_hegs2_template(rocblas_handle handle,
 
                 rocblasCall_trmv<T>(handle, uplo, rocblas_operation_none, rocblas_diagonal_non_unit,
                                     k, B, shiftB, ldb, strideB, A, shiftA + idx2D(0, k, lda), 1,
-                                    strideA, (T*)work_wur, strideW, batch_count);
+                                    strideA, (T*)work, strideW, batch_count);
 
                 rocblasCall_axpy<T>(handle, k, ((T*)store_wcs) + 1, strideS, B,
                                     shiftB + idx2D(0, k, ldb), 1, strideB, A,
@@ -366,7 +367,7 @@ rocblas_status rocsolver_sygs2_hegs2_template(rocblas_handle handle,
 
                 rocblasCall_trmv<T>(handle, uplo, rocblas_operation_conjugate_transpose,
                                     rocblas_diagonal_non_unit, k, B, shiftB, ldb, strideB, A,
-                                    shiftA + idx2D(k, 0, lda), lda, strideA, (T*)work_wur, strideW,
+                                    shiftA + idx2D(k, 0, lda), lda, strideA, (T*)work, strideW,
                                     batch_count);
 
                 if(COMPLEX)

--- a/library/src/lapack/roclapack_sygs2_hegs2_batched.cpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2_batched.cpp
@@ -40,25 +40,25 @@ rocblas_status rocsolver_sygs2_hegs2_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSV or TRMV)
-    size_t size_work_wur, size_store_wcs;
+    size_t size_work, size_store_wcs;
     // size of array of pointers (only for batched case)
     size_t size_workArr;
-    rocsolver_sygs2_hegs2_getMemorySize<T, true>(itype, n, batch_count, &size_scalars,
-                                                 &size_work_wur, &size_store_wcs, &size_workArr);
+    rocsolver_sygs2_hegs2_getMemorySize<T, true>(itype, n, batch_count, &size_scalars, &size_work,
+                                                 &size_store_wcs, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_wur,
+        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work,
                                                       size_store_wcs, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work_wur, *store_wcs, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_wur, size_store_wcs, size_workArr);
+    void *scalars, *work, *store_wcs, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work, size_store_wcs, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_wur = mem[1];
+    work = mem[1];
     store_wcs = mem[2];
     workArr = mem[3];
     if(size_scalars > 0)
@@ -67,7 +67,7 @@ rocblas_status rocsolver_sygs2_hegs2_batched_impl(rocblas_handle handle,
     // execution
     return rocsolver_sygs2_hegs2_template<true, T>(handle, itype, uplo, n, A, shiftA, lda, strideA,
                                                    B, shiftB, ldb, strideB, batch_count,
-                                                   (T*)scalars, work_wur, store_wcs, (T**)workArr);
+                                                   (T*)scalars, work, store_wcs, (T**)workArr);
 }
 
 /*

--- a/library/src/lapack/roclapack_sygs2_hegs2_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygs2_hegs2_strided_batched.cpp
@@ -38,25 +38,25 @@ rocblas_status rocsolver_sygs2_hegs2_strided_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSV or TRMV)
-    size_t size_work_wur, size_store_wcs;
+    size_t size_work, size_store_wcs;
     // size of array of pointers (only for batched case)
     size_t size_workArr;
-    rocsolver_sygs2_hegs2_getMemorySize<T, false>(itype, n, batch_count, &size_scalars,
-                                                  &size_work_wur, &size_store_wcs, &size_workArr);
+    rocsolver_sygs2_hegs2_getMemorySize<T, false>(itype, n, batch_count, &size_scalars, &size_work,
+                                                  &size_store_wcs, &size_workArr);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_wur,
+        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work,
                                                       size_store_wcs, size_workArr);
 
     // memory workspace allocation
-    void *scalars, *work_wur, *store_wcs, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_wur, size_store_wcs, size_workArr);
+    void *scalars, *work, *store_wcs, *workArr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work, size_store_wcs, size_workArr);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_wur = mem[1];
+    work = mem[1];
     store_wcs = mem[2];
     workArr = mem[3];
     if(size_scalars > 0)
@@ -65,7 +65,7 @@ rocblas_status rocsolver_sygs2_hegs2_strided_batched_impl(rocblas_handle handle,
     // execution
     return rocsolver_sygs2_hegs2_template<false, T>(handle, itype, uplo, n, A, shiftA, lda, strideA,
                                                     B, shiftB, ldb, strideB, batch_count,
-                                                    (T*)scalars, work_wur, store_wcs, (T**)workArr);
+                                                    (T*)scalars, work, store_wcs, (T**)workArr);
 }
 
 /*

--- a/library/src/lapack/roclapack_sygst_hegst.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst.cpp
@@ -40,13 +40,13 @@ rocblas_status rocsolver_sygst_hegst_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSV or TRMV)
-    size_t size_work_wur_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
+    size_t size_work_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
     rocsolver_sygst_hegst_getMemorySize<T, false>(itype, n, batch_count, &size_scalars,
-                                                  &size_work_wur_x_temp, &size_workArr_temp_arr,
+                                                  &size_work_x_temp, &size_workArr_temp_arr,
                                                   &size_store_wcs_invA, &size_invA_arr);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_wur_x_temp,
+        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_x_temp,
                                                       size_workArr_temp_arr, size_store_wcs_invA,
                                                       size_invA_arr);
 
@@ -54,15 +54,15 @@ rocblas_status rocsolver_sygst_hegst_impl(rocblas_handle handle,
     bool optim_mem = true;
 
     // memory workspace allocation
-    void *scalars, *work_wur_x_temp, *workArr_temp_arr, *store_wcs_invA, *invA_arr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_wur_x_temp, size_workArr_temp_arr,
+    void *scalars, *work_x_temp, *workArr_temp_arr, *store_wcs_invA, *invA_arr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work_x_temp, size_workArr_temp_arr,
                               size_store_wcs_invA, size_invA_arr);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_wur_x_temp = mem[1];
+    work_x_temp = mem[1];
     workArr_temp_arr = mem[2];
     store_wcs_invA = mem[3];
     invA_arr = mem[4];
@@ -72,7 +72,7 @@ rocblas_status rocsolver_sygst_hegst_impl(rocblas_handle handle,
     // execution
     return rocsolver_sygst_hegst_template<false, false, S, T>(
         handle, itype, uplo, n, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count,
-        (T*)scalars, work_wur_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr, optim_mem);
+        (T*)scalars, work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr, optim_mem);
 }
 
 /*

--- a/library/src/lapack/roclapack_sygst_hegst.hpp
+++ b/library/src/lapack/roclapack_sygst_hegst.hpp
@@ -18,7 +18,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
                                          const rocblas_int n,
                                          const rocblas_int batch_count,
                                          size_t* size_scalars,
-                                         size_t* size_work_wur_x_temp,
+                                         size_t* size_work_x_temp,
                                          size_t* size_workArr_temp_arr,
                                          size_t* size_store_wcs_invA,
                                          size_t* size_invA_arr)
@@ -27,7 +27,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
     if(n == 0 || batch_count == 0)
     {
         *size_scalars = 0;
-        *size_work_wur_x_temp = 0;
+        *size_work_x_temp = 0;
         *size_workArr_temp_arr = 0;
         *size_store_wcs_invA = 0;
         *size_invA_arr = 0;
@@ -38,7 +38,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
     {
         // requirements for calling a single SYGS2/HEGS2
         rocsolver_sygs2_hegs2_getMemorySize<T, BATCHED>(itype, n, batch_count, size_scalars,
-                                                        size_work_wur_x_temp, size_store_wcs_invA,
+                                                        size_work_x_temp, size_store_wcs_invA,
                                                         size_workArr_temp_arr);
         *size_invA_arr = 0;
     }
@@ -49,7 +49,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
 
         // requirements for calling SYGS2/HEGS2 for the subblocks
         rocsolver_sygs2_hegs2_getMemorySize<T, BATCHED>(itype, kb, batch_count, size_scalars,
-                                                        size_work_wur_x_temp, size_store_wcs_invA,
+                                                        size_work_x_temp, size_store_wcs_invA,
                                                         size_workArr_temp_arr);
         *size_invA_arr = 0;
 
@@ -61,7 +61,7 @@ void rocsolver_sygst_hegst_getMemorySize(const rocblas_eform itype,
             rocblasCall_trsm_mem<BATCHED, T>(rocblas_side_right, n - kb, kb, batch_count, &temp5,
                                              &temp6, &temp7, &temp8);
 
-            *size_work_wur_x_temp = max(*size_work_wur_x_temp, max(temp1, temp5));
+            *size_work_x_temp = max(*size_work_x_temp, max(temp1, temp5));
             *size_workArr_temp_arr = max(*size_workArr_temp_arr, max(temp2, temp6));
             *size_store_wcs_invA = max(*size_store_wcs_invA, max(temp3, temp7));
             *size_invA_arr = max(*size_invA_arr, max(temp4, temp8));
@@ -84,7 +84,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                                               const rocblas_stride strideB,
                                               const rocblas_int batch_count,
                                               T* scalars,
-                                              void* work_wur_x_temp,
+                                              void* work_x_temp,
                                               void* workArr_temp_arr,
                                               void* store_wcs_invA,
                                               void* invA_arr,
@@ -106,7 +106,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
     if(n <= nb)
         return rocsolver_sygs2_hegs2_template<BATCHED, T>(
             handle, itype, uplo, n, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count,
-            scalars, work_wur_x_temp, store_wcs_invA, (T**)workArr_temp_arr);
+            scalars, work_x_temp, store_wcs_invA, (T**)workArr_temp_arr);
 
     // everything must be executed with scalars on the host
     rocblas_pointer_mode old_mode;
@@ -130,7 +130,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
 
                 rocsolver_sygs2_hegs2_template<BATCHED, T>(
                     handle, itype, uplo, kb, A, shiftA + idx2D(k, k, lda), lda, strideA, B,
-                    shiftB + idx2D(k, k, ldb), ldb, strideB, batch_count, scalars, work_wur_x_temp,
+                    shiftB + idx2D(k, k, ldb), ldb, strideB, batch_count, scalars, work_x_temp,
                     store_wcs_invA, (T**)workArr_temp_arr);
 
                 if(k + kb < n)
@@ -139,7 +139,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                         handle, rocblas_side_left, uplo, rocblas_operation_conjugate_transpose,
                         rocblas_diagonal_non_unit, kb, n - k - kb, &t_one, B,
                         shiftB + idx2D(k, k, ldb), ldb, strideB, A, shiftA + idx2D(k, k + kb, lda),
-                        lda, strideA, batch_count, optim_mem, work_wur_x_temp, workArr_temp_arr,
+                        lda, strideA, batch_count, optim_mem, work_x_temp, workArr_temp_arr,
                         store_wcs_invA, invA_arr);
 
                     rocblasCall_symm_hemm<T>(handle, rocblas_side_left, uplo, kb, n - k - kb,
@@ -165,7 +165,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                         rocblas_diagonal_non_unit, kb, n - k - kb, &t_one, B,
                         shiftB + idx2D(k + kb, k + kb, ldb), ldb, strideB, A,
                         shiftA + idx2D(k, k + kb, lda), lda, strideA, batch_count, optim_mem,
-                        work_wur_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
+                        work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
                 }
             }
         }
@@ -178,7 +178,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
 
                 rocsolver_sygs2_hegs2_template<BATCHED, T>(
                     handle, itype, uplo, kb, A, shiftA + idx2D(k, k, lda), lda, strideA, B,
-                    shiftB + idx2D(k, k, ldb), ldb, strideB, batch_count, scalars, work_wur_x_temp,
+                    shiftB + idx2D(k, k, ldb), ldb, strideB, batch_count, scalars, work_x_temp,
                     store_wcs_invA, (T**)workArr_temp_arr);
 
                 if(k + kb < n)
@@ -187,7 +187,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                         handle, rocblas_side_right, uplo, rocblas_operation_conjugate_transpose,
                         rocblas_diagonal_non_unit, n - k - kb, kb, &t_one, B,
                         shiftB + idx2D(k, k, ldb), ldb, strideB, A, shiftA + idx2D(k + kb, k, lda),
-                        lda, strideA, batch_count, optim_mem, work_wur_x_temp, workArr_temp_arr,
+                        lda, strideA, batch_count, optim_mem, work_x_temp, workArr_temp_arr,
                         store_wcs_invA, invA_arr);
 
                     rocblasCall_symm_hemm<T>(handle, rocblas_side_right, uplo, n - k - kb, kb,
@@ -213,7 +213,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                         rocblas_diagonal_non_unit, n - k - kb, kb, &t_one, B,
                         shiftB + idx2D(k + kb, k + kb, ldb), ldb, strideB, A,
                         shiftA + idx2D(k + kb, k, lda), lda, strideA, batch_count, optim_mem,
-                        work_wur_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
+                        work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
                 }
             }
         }
@@ -255,7 +255,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
 
                 rocsolver_sygs2_hegs2_template<BATCHED, T>(
                     handle, itype, uplo, kb, A, shiftA + idx2D(k, k, lda), lda, strideA, B,
-                    shiftB + idx2D(k, k, ldb), ldb, strideB, batch_count, scalars, work_wur_x_temp,
+                    shiftB + idx2D(k, k, ldb), ldb, strideB, batch_count, scalars, work_x_temp,
                     store_wcs_invA, (T**)workArr_temp_arr);
             }
         }
@@ -294,7 +294,7 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
 
                 rocsolver_sygs2_hegs2_template<BATCHED, T>(
                     handle, itype, uplo, kb, A, shiftA + idx2D(k, k, lda), lda, strideA, B,
-                    shiftB + idx2D(k, k, ldb), ldb, strideB, batch_count, scalars, work_wur_x_temp,
+                    shiftB + idx2D(k, k, ldb), ldb, strideB, batch_count, scalars, work_x_temp,
                     store_wcs_invA, (T**)workArr_temp_arr);
             }
         }

--- a/library/src/lapack/roclapack_sygst_hegst_batched.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst_batched.cpp
@@ -42,13 +42,13 @@ rocblas_status rocsolver_sygst_hegst_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSV or TRMV)
-    size_t size_work_wur_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
+    size_t size_work_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
     rocsolver_sygst_hegst_getMemorySize<T, true>(itype, n, batch_count, &size_scalars,
-                                                 &size_work_wur_x_temp, &size_workArr_temp_arr,
+                                                 &size_work_x_temp, &size_workArr_temp_arr,
                                                  &size_store_wcs_invA, &size_invA_arr);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_wur_x_temp,
+        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_x_temp,
                                                       size_workArr_temp_arr, size_store_wcs_invA,
                                                       size_invA_arr);
 
@@ -57,7 +57,7 @@ rocblas_status rocsolver_sygst_hegst_batched_impl(rocblas_handle handle,
 
     // memory workspace allocation
     void *scalars, *work_x_temp, *workArr_temp_arr, *store_invA, *invA_arr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_wur_x_temp, size_workArr_temp_arr,
+    rocblas_device_malloc mem(handle, size_scalars, size_work_x_temp, size_workArr_temp_arr,
                               size_store_wcs_invA, size_invA_arr);
 
     if(!mem)

--- a/library/src/lapack/roclapack_sygst_hegst_strided_batched.cpp
+++ b/library/src/lapack/roclapack_sygst_hegst_strided_batched.cpp
@@ -40,13 +40,13 @@ rocblas_status rocsolver_sygst_hegst_strided_batched_impl(rocblas_handle handle,
     // size for constants in rocblas calls
     size_t size_scalars;
     // size of reusable workspace (and for calling TRSV or TRMV)
-    size_t size_work_wur_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
+    size_t size_work_x_temp, size_workArr_temp_arr, size_store_wcs_invA, size_invA_arr;
     rocsolver_sygst_hegst_getMemorySize<T, false>(itype, n, batch_count, &size_scalars,
-                                                  &size_work_wur_x_temp, &size_workArr_temp_arr,
+                                                  &size_work_x_temp, &size_workArr_temp_arr,
                                                   &size_store_wcs_invA, &size_invA_arr);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_wur_x_temp,
+        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_x_temp,
                                                       size_workArr_temp_arr, size_store_wcs_invA,
                                                       size_invA_arr);
 
@@ -54,15 +54,15 @@ rocblas_status rocsolver_sygst_hegst_strided_batched_impl(rocblas_handle handle,
     bool optim_mem = true;
 
     // memory workspace allocation
-    void *scalars, *work_wur_x_temp, *workArr_temp_arr, *store_wcs_invA, *invA_arr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_wur_x_temp, size_workArr_temp_arr,
+    void *scalars, *work_x_temp, *workArr_temp_arr, *store_wcs_invA, *invA_arr;
+    rocblas_device_malloc mem(handle, size_scalars, size_work_x_temp, size_workArr_temp_arr,
                               size_store_wcs_invA, size_invA_arr);
 
     if(!mem)
         return rocblas_status_memory_error;
 
     scalars = mem[0];
-    work_wur_x_temp = mem[1];
+    work_x_temp = mem[1];
     workArr_temp_arr = mem[2];
     store_wcs_invA = mem[3];
     invA_arr = mem[4];
@@ -72,7 +72,7 @@ rocblas_status rocsolver_sygst_hegst_strided_batched_impl(rocblas_handle handle,
     // execution
     return rocsolver_sygst_hegst_template<false, true, S, T>(
         handle, itype, uplo, n, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count,
-        (T*)scalars, work_wur_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr, optim_mem);
+        (T*)scalars, work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr, optim_mem);
 }
 
 /*


### PR DESCRIPTION
Minor adjustments to your trsv PR. Memory access fault appears to be fixed on my machine by properly setting size_work_wur to 0. I also renamed work_wur to wur, since w_unique_row has been removed from the trsv call.